### PR TITLE
Fixed bug with events not updating

### DIFF
--- a/bin/get_events
+++ b/bin/get_events
@@ -25,7 +25,7 @@ output = {}.tap do |out|
   GROUPS.each do |group|
     print "  #{group}:"
     out[group.to_s] = {"events" => []}
-    uri = "https://api.meetup.com/2/events?&sign=true&photo-host=public&group_urlname=#{group}&status=upcoming,past,proposed,suggested&page=20&key=#{ENV['MEETUP_API_KEY']}"
+    uri = "https://api.meetup.com/2/events?&sign=true&photo-host=public&group_urlname=#{group}&status=upcoming,past,proposed,suggested&key=#{ENV['MEETUP_API_KEY']}"
 
     begin
       json = URI.parse(uri).open.read


### PR DESCRIPTION
@scouttyg informed me that the events on a2rb.org were not updating. After doing some investigating I tracked down the bug to the script that hits the Meetup API to refresh the events list. There was a 'page' parameter in the request url that was limiting the results to 20. When I tried the url without that parameter it returned the full list of events.